### PR TITLE
Remove trailing space not required for formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The [Android Software Development Kit](https://developer.android.com/sdk/index.h
 
 This recipe parses two XML files that Google uses to inform the URLs, versions, and names of all packages related to the SDK. The Android SDK installer, which is a Java app, can download all of these manually (and uses those two XML URLs to figure out what to download).
 
-This is a *minimal* set of packages necessary to start developing with the Android SDK. It is not the *complete* SDK. 
+This is a *minimal* set of packages necessary to start developing with the Android SDK. It is not the *complete* SDK.
 
 The Android SDK requires Java 7 in order to function.
 

--- a/Shared_Processors/README.md
+++ b/Shared_Processors/README.md
@@ -87,7 +87,7 @@ This example will calculate the SHA-256 sum:
 ```
 
 ## SubDirectoryList
-This is a more complex processor with more specific usage.  For a given root path, this processor will walk through and create two lists: one for all files found relative to the root path, and one for all directories found relative to the root path. 
+This is a more complex processor with more specific usage.  For a given root path, this processor will walk through and create two lists: one for all files found relative to the root path, and one for all directories found relative to the root path.
 
 Both of these lists are stored as strings, with each item separated by the contents of the "suffix_string" input variable (which defaults to "," comma).
 

--- a/Xcode/README.md
+++ b/Xcode/README.md
@@ -1,11 +1,11 @@
 # Xcode Recipes
 
-This folder contains fully functioning Xcode download, extraction, and Munki 
+This folder contains fully functioning Xcode download, extraction, and Munki
 recipes.
 
 ## Use Overrides to download
 
-To download Xcode, you need to create an override with the following two input 
+To download Xcode, you need to create an override with the following two input
 variables:
 * APPLE_ID: an AppleID that has access to the developer downloads portal
 * PASSWORD: the password to the AppleID
@@ -14,30 +14,30 @@ variables:
 
 This override can be used for the .download alone, or with the .munki recipes.
 
-*WARNING! Your password will appear in plain text in the AutoPkg verbose logs. 
+*WARNING! Your password will appear in plain text in the AutoPkg verbose logs.
 If you use more than one -v, this password will not be secret.*
 
 ## A note about version numbers
 
-These recipes extract the major, minor, and patch versions from the version 
-numbers, as well as what Apple refers to as the "bundle" version, as well as 
-the build number. This is because Apple has, at various times, bumped a beta of 
-Xcode into GM version by only increasing the build number one digit, and yet 
-somehow still introduced functional changes. 
+These recipes extract the major, minor, and patch versions from the version
+numbers, as well as what Apple refers to as the "bundle" version, as well as
+the build number. This is because Apple has, at various times, bumped a beta of
+Xcode into GM version by only increasing the build number one digit, and yet
+somehow still introduced functional changes.
 
-Because of the fact that any possible release of Xcode could behave differently 
-than identically-numbered previous releases, we use all possible version data 
+Because of the fact that any possible release of Xcode could behave differently
+than identically-numbered previous releases, we use all possible version data
 to differentiate Xcode releases.
 
-THe build number is used in the Display Name only, and not included in the 
+THe build number is used in the Display Name only, and not included in the
 version information used by Munki to determine install status.
 
 ## Recipes
 
 ### Xcode.munki Recipe
 
-This is the "classic" Xcode Munki recipe. It will import an item into Munki 
-simply named "Xcode", and installs into "/Applications/Xcode.app", similar to 
+This is the "classic" Xcode Munki recipe. It will import an item into Munki
+simply named "Xcode", and installs into "/Applications/Xcode.app", similar to
 how the App Store version behaves.
 
 Example output:
@@ -50,17 +50,17 @@ The following new items were imported into Munki:
 
 ### XcodeVersionedName.munki Recipe
 
-If you want to be able to install multiple versions of Xcode side-by-side, or 
-otherwise want to differentiate each version of Xcode, we can't name each 
+If you want to be able to install multiple versions of Xcode side-by-side, or
+otherwise want to differentiate each version of Xcode, we can't name each
 version "Xcode". Instead, each version of Xcode is individually named.
 
-This Munki recipe imports an item named "XcodeMajorMinorPatch", where the 
+This Munki recipe imports an item named "XcodeMajorMinorPatch", where the
 numbers are inserted accordingly: "Xcode10.2.1".
 
-Unlike the regular Xcode.munki recipe, this recipe also renames the .app on 
-disk. The app that is installed on disk is named similarly, 
-"/Applications/Xcode_10.2.1.app". The disk image that the recipe produces is 
-named similarly as well, although the DMG name is ignored by Munki as it 
+Unlike the regular Xcode.munki recipe, this recipe also renames the .app on
+disk. The app that is installed on disk is named similarly,
+"/Applications/Xcode_10.2.1.app". The disk image that the recipe produces is
+named similarly as well, although the DMG name is ignored by Munki as it
 renames it accordingly.
 
 Example output:
@@ -73,20 +73,20 @@ The following new items were imported into Munki:
 
 ### XcodeCLITools.download
 
-This download recipe shows how you can easily create new recipes, or even 
-overrides, that change what files to look for in the list of URLs from the 
+This download recipe shows how you can easily create new recipes, or even
+overrides, that change what files to look for in the list of URLs from the
 download portal.
 
-This recipe will download the Command Line Tools for a given version of macOS, 
-which is specified as the `MACOS_VERSION` input variable. You could swap this 
-out for previous versions of macOS, although please bear in mind that Apple 
-has a tendency to change naming conventions randomly with new versions, so the 
+This recipe will download the Command Line Tools for a given version of macOS,
+which is specified as the `MACOS_VERSION` input variable. You could swap this
+out for previous versions of macOS, although please bear in mind that Apple
+has a tendency to change naming conventions randomly with new versions, so the
 existing regex pattern might break at any time.
 
 ## How It Works
 
 ### Getting the cookies
-There are three custom processors that are used to get the right download data. 
+There are three custom processors that are used to get the right download data.
 First, the AppleDataGatherer simply takes the AppleID & password data and writes
 it out to a file, which is passed to curl. This is done to avoid having the
 password show up in the process list.
@@ -96,38 +96,38 @@ login data generated by AppleDataGatherer to generate the "myacinfo" cookie
 stored in "login_cookies". The second one uses the login_cookie to get access
 to the download list, which generates the "download_cookies".
 
-With the necessary cookies created, we can now access the downloads list. This 
-list is actually a json blob inside a gz archive, so we must use `gunzip` to 
-extract it, and then serialize it into JSON data. If the access creds fail, this 
-will be how we tell - the downloads list will actually be raw JSON indicating an 
+With the necessary cookies created, we can now access the downloads list. This
+list is actually a json blob inside a gz archive, so we must use `gunzip` to
+extract it, and then serialize it into JSON data. If the access creds fail, this
+will be how we tell - the downloads list will actually be raw JSON indicating an
 error response from the server, rather than JSON wrapped in gzip.
 
 ### Parsing the list of downloads
-The file is stored inside the AutoPkg cache, in 
+The file is stored inside the AutoPkg cache, in
 `%RECIPE_CACHE_DIR%/downloads/listDownloads`. You can read this file yourself if
  you wish to see a full list of all information available for download.
 
-We use regex to parse the list of download URLs for the given pattern we want. 
+We use regex to parse the list of download URLs for the given pattern we want.
 The result will be a single download URL that can be passed to URLDownloader,
 which also uses the download cookie to access the data.
 
 ### Xip extraction
 
 Hat tip to Graham Gilbert for pointing out that `xip --extract` does a great job
-at extracting xips without all the hard work of using xar, cpio, or pbzx 
+at extracting xips without all the hard work of using xar, cpio, or pbzx
 madness.
 
 ## Important Notes
 
 Xcode is a nasty beast. Apple has no compunction against changing it any time of
-day or night, or renaming it, or breaking assumptions. Since they provide no 
-useful API of any kind to automate this, we have to use hacky workarounds like 
+day or night, or renaming it, or breaking assumptions. Since they provide no
+useful API of any kind to automate this, we have to use hacky workarounds like
 this to do something straightforward like downloading software.
 
 Be warned that it could break at any moment.
 
-Also, Xcode is a roughly ~5 GB download, so depending on your internet, the 
-download portion alone could take significant time. Then, extracting the xip 
-into the app takes at least 10-15 minutes on an SSD drive. Then we need to 
-wrap the app in a disk image, which takes another 10-15 minutes depending on 
+Also, Xcode is a roughly ~5 GB download, so depending on your internet, the
+download portion alone could take significant time. Then, extracting the xip
+into the app takes at least 10-15 minutes on an SSD drive. Then we need to
+wrap the app in a disk image, which takes another 10-15 minutes depending on
 your machine.


### PR DESCRIPTION
Remove trailing space from Markdown files.

Note: Trailing space that is [used to insert a `<br />`](https://daringfireball.net/projects/markdown/syntax#philosophy) is not affected by this change:

> When you do want to insert a `<br />` break tag using Markdown, you end a line with two or more spaces, then type return.
