### PR TITLE
Add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+repos:
+- repo: https://github.com/homebysix/pre-commit-macadmin
+  rev: v1.4.0
+  hooks:
+  - id: check-autopkg-recipes
+    args: ['--recipe-prefix=com.facebook.autopkg.']
+  - id: forbid-autopkg-overrides
+  - id: forbid-autopkg-trust-info
+  - id: check-plists
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.2.3
+  hooks:
+  - id: check-added-large-files
+    args: [--maxkb=100]
+  - id: check-ast
+  - id: check-byte-order-marker
+  - id: check-case-conflict
+  - id: check-docstring-first
+  - id: check-merge-conflict
+  - id: end-of-file-fixer
+  - id: fix-encoding-pragma
+  - id: mixed-line-ending
+  - id: trailing-whitespace
+    args: [--markdown-linebreak-ext=md]


### PR DESCRIPTION
This pre-commit configuration includes some AutoPkg-specific checks, forbids the commit of AutoPkg overrides or trust info, and ensures all plists pass linting.

It also includes some more general checks: preventing unresolved merge conflicts, preventing case sensitivity issues, cleaning up trailing whitespace, and checking that Python files parse with `ast`.

This PR should be merged _after_ #27, #28, and #29.