### PR TITLE
Major version naming and arbitrary suffix

### DIFF
--- a/Xcode/README.md
+++ b/Xcode/README.md
@@ -52,10 +52,10 @@ The following new items were imported into Munki:
 
 If you want to be able to install multiple versions of Xcode side-by-side, or
 otherwise want to differentiate each version of Xcode, we can't name each
-version "Xcode". Instead, each version of Xcode is individually named.
+version "Xcode". Instead, each version of Xcode is named by major version.
 
-This Munki recipe imports an item named "XcodeMajorMinorPatch", where the
-numbers are inserted accordingly: "Xcode10.2.1".
+This Munki recipe imports an item named "XcodeMajor", where the
+numbers are inserted accordingly: "Xcode10".
 
 Unlike the regular Xcode.munki recipe, this recipe also renames the .app on
 disk. The app that is installed on disk is named similarly,
@@ -68,7 +68,7 @@ Example output:
 The following new items were imported into Munki:
     Name         Version           Catalogs  Pkginfo Path                                         Pkg Repo Path
     ----         -------           --------  ------------                                         -------------
-    Xcode10.2.1  10.2.1.14490.122  testing   apps/apple/xcode/Xcode10.2.1-10.2.1.14490.122.plist  apps/apple/xcode/Xcode_10.2-10.2.1.14490.122.dmg
+    Xcode10  10.2.1.14490.122  testing   apps/apple/xcode/Xcode10.2.1-10.2.1.14490.122.plist  apps/apple/xcode/Xcode_10.2-10.2.1.14490.122.dmg
 ```
 
 ### XcodeCLITools.download

--- a/Xcode/XcodeVersionedName.munki.recipe
+++ b/Xcode/XcodeVersionedName.munki.recipe
@@ -20,8 +20,11 @@
 		<string>apps/apple/xcode/</string>
 		<key>NAME</key>
 		<string>Xcode</string>
-		<key>PASSWORD</key>
-		<string>password</string>
+		<key>PASSWORD_FILE</key>
+		<string>secret.txt</string>
+		<!-- Arbitrary_suffix optionally adds string between Xcode_X.Y.Z and .app -->
+		<key>ARBITRARY_SUFFIX</key>
+		<string></string>
 		<key>pkginfo</key>
 		<dict>
 			<key>catalogs</key>
@@ -59,7 +62,7 @@
 				<key>source</key>
 				<string>%found_filename%</string>
 				<key>target</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%_%major_version%.%minor_version%.%patch_version%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%_%major_version%.%minor_version%.%patch_version%%ARBITRARY_SUFFIX%.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>FileMover</string>
@@ -70,7 +73,7 @@
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%_%major_version%.%minor_version%.%patch_version%.dmg</string>
 				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%_%major_version%.%minor_version%.%patch_version%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%_%major_version%.%minor_version%.%patch_version%%ARBITRARY_SUFFIX%.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>DmgCreator</string>
@@ -85,7 +88,7 @@
 					<key>icon_name</key>
 					<string>%ICON_NAME%</string>
 					<key>name</key>
-					<string>%NAME%%major_version%.%minor_version%.%patch_version%</string>
+					<string>%NAME%%major_version%</string>
 					<key>version</key>
 					<string>%major_version%.%minor_version%.%patch_version%.%bundle_version%</string>
 				</dict>
@@ -110,7 +113,7 @@
 				<key>path_list</key>
 				<array>
 					<string>%RECIPE_CACHE_DIR%/%NAME%_unpack</string>
-					<string>%RECIPE_CACHE_DIR%/%NAME%_%major_version%.%minor_version%.%patch_version%.app</string>
+					<string>%RECIPE_CACHE_DIR%/%NAME%_%major_version%.%minor_version%.%patch_version%%ARBITRARY_SUFFIX%.app</string>
 				</array>
 			</dict>
 			<key>Processor</key>

--- a/Xcode/XcodeVersionedName.munki.recipe
+++ b/Xcode/XcodeVersionedName.munki.recipe
@@ -84,13 +84,13 @@
 				<key>additional_pkginfo</key>
 				<dict>
 					<key>display_name</key>
-					<string>%NAME% %major_version%.%minor_version%.%patch_version% (%productbuildversion%)</string>
+					<string>%NAME% %major_version%.%minor_version%.%patch_version%</string>
 					<key>icon_name</key>
 					<string>%ICON_NAME%</string>
 					<key>name</key>
 					<string>%NAME%%major_version%</string>
 					<key>version</key>
-					<string>%major_version%.%minor_version%.%patch_version%.%bundle_version%</string>
+					<string>%major_version%.%minor_version%.%patch_version%</string>
 				</dict>
 			</dict>
 			<key>Processor</key>


### PR DESCRIPTION
Versioned Xcodes are now imported as `XcodeX` instead of `XcodeX.Y.Z`, so minor and patch versions will be upgraded as new versions are imported.

Also adds the ability to insert an optional arbitrary string, for cosmetic/political reasons.