### PR TITLE
Match min OS vers to host OS requirements

### DIFF
--- a/VMwareFusionDeploy/VMwareFusionDeploy.munki.recipe
+++ b/VMwareFusionDeploy/VMwareFusionDeploy.munki.recipe
@@ -44,6 +44,8 @@ key = XXXXX-XXXXX-XXXXX-XXXXX-XXXXX
 			<string>VMware</string>
 			<key>display_name</key>
 			<string>VMWare Fusion Pro</string>
+			<key>minimum_os_version</key>
+			<string>10.13</string>
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>uninstall_method</key>


### PR DESCRIPTION
According to this doc, the host OS must be running macOS 10.13 or greater for VMware Fusion 11: https://docs.vmware.com/en/VMware-Fusion/11/com.vmware.fusion.using.doc/GUID-84E34BF1-92A2-4B86-9995-70893A9B04A9.html