### PR TITLE
Fix unused variable

### DIFF
--- a/Xcode/XcodeVersioner.py
+++ b/Xcode/XcodeVersioner.py
@@ -63,7 +63,7 @@ class XcodeVersioner(Processor):
 
     def _load_objc_framework(self, f_name, f_path, class_whitelist):
         loaded = {}
-        framework_bundle = objc.loadBundle(  # NOQA
+        _ = objc.loadBundle(
             f_name, bundle_path=f_path, module_globals=loaded
         )
         desired = {}


### PR DESCRIPTION
Use _ as the variable name instead of suppressing lint.

Not assigning also works, but this seems safer (in case some future version of Python
either optimizes away calls that are only for side effects, or warn about unused
results).

Fixes #49.

Before:
```
❯ flake8 Xcode/XcodeVersioner.py
Xcode/XcodeVersioner.py:33:80: E501 line too long (83 > 79 characters)
Xcode/XcodeVersioner.py:40:80: E501 line too long (83 > 79 characters)
Xcode/XcodeVersioner.py:45:80: E501 line too long (86 > 79 characters)
Xcode/XcodeVersioner.py:57:80: E501 line too long (84 > 79 characters)
```

After:
```
❯ flake8 Xcode/XcodeVersioner.py
Xcode/XcodeVersioner.py:33:80: E501 line too long (83 > 79 characters)
Xcode/XcodeVersioner.py:40:80: E501 line too long (83 > 79 characters)
Xcode/XcodeVersioner.py:45:80: E501 line too long (86 > 79 characters)
Xcode/XcodeVersioner.py:57:80: E501 line too long (84 > 79 characters)
```

Signed-off-by: Michel Salim <michel@fb.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/facebook/recipes-for-autopkg/50)
<!-- Reviewable:end -->
