### PR TITLE
Remove variable from input key value

### DIFF
--- a/Xcode/Xcode.download.recipe
+++ b/Xcode/Xcode.download.recipe
@@ -22,7 +22,7 @@
       <key>NOSKIP</key>
       <string></string>
       <key>VERSION_EMIT_PATH</key>
-      <string>%RECIPE_CACHE_DIR%/xcode_tag</string>
+      <string>xcode_tag</string>
     </dict>
     <key>MinimumVersion</key>
     <string>1.0.4</string>

--- a/Xcode/Xcode.extract.recipe
+++ b/Xcode/Xcode.extract.recipe
@@ -12,7 +12,7 @@
     <key>NAME</key>
     <string>Xcode</string>
     <key>BUILD_NUMBER_EMIT_PATH</key>
-    <string>%RECIPE_CACHE_DIR%/xcode_build_number</string>
+    <string>xcode_build_number</string>
   </dict>
   <key>MinimumVersion</key>
   <string>1.0.4</string>


### PR DESCRIPTION
When a variable substitution is in an input key, it's used before it's assigned and causes:

```
Use of undefined key in variable substitution: 'RECIPE_CACHE_DIR'
```

(I'm assuming you do not have logic that is making use of this, some other way -- I have a processor where I can force this to work, so I don't know if you're doing something similar.)