### PR TITLE
Update configparser code for py3

### DIFF
--- a/SQLDeveloper/SQLDeveloperVersioner.py
+++ b/SQLDeveloper/SQLDeveloperVersioner.py
@@ -19,29 +19,12 @@
 
 from __future__ import absolute_import
 
-import ConfigParser
+import configparser
 import os.path
 
 from autopkglib import Processor, ProcessorError
 
 __all__ = ["SQLDeveloperVersioner"]
-
-
-# this code stolen directly from
-# http://stackoverflow.com/questions/2819696/parsing-properties-file-in-python/2819788#2819788
-class FakeSecHead(object):
-    def __init__(self, fp):
-        self.fp = fp
-        self.sechead = "[properties]\n"
-
-    def readline(self):
-        if self.sechead:
-            try:
-                return self.sechead
-            finally:
-                self.sechead = None
-        else:
-            return self.fp.readline()
 
 
 class SQLDeveloperVersioner(Processor):
@@ -62,15 +45,25 @@ class SQLDeveloperVersioner(Processor):
         # the app's Info.plist.  Instead, the actual version is buried deep
         # inside in a file called "version.properties". Thanks, Oracle.
         # You know, I was a having a pretty good day up until now...
+
+        # this code stolen from Oscar de Groot's answer at:
+        # https://stackoverflow.com/questions/2819696/parsing-properties-file-in-python
+        def add_section_header(properties_file, header_name):
+            yield '[{}]\n'.format(header_name)
+            for line in properties_file:
+                yield line
+
         relative_path = (
             "Contents/Resources/sqldeveloper/sqldeveloper/bin/version.properties"
         )
         file_path = os.path.join(self.env["app_path"], relative_path)
-        # this code stolen directly from
-        # http://stackoverflow.com/questions/2819696/parsing-properties-file-in-python/2819788#2819788
-        cp = ConfigParser.SafeConfigParser()
+        # this code stolen from Oscar de Groot's answer at:
+        # https://stackoverflow.com/questions/2819696/parsing-properties-file-in-python
+
+        file = open(file_path, encoding="utf_8")
+        cp = configparser.ConfigParser()
         try:
-            cp.readfp(FakeSecHead(open(file_path)))
+            cp.read_file(add_section_header(file, 'properties'), source=file_path)
         except IOError as err:
             raise ProcessorError(err)
         self.env["version"] = cp.get("properties", "ver_full")


### PR DESCRIPTION
Updated the configparser code to be python3 compatible, removed the stackoverflow stolen bits (and re-stole from the same place - but from a python3-compatible answer!). Initial testing works without issue with the current version of SQLDeveloper. No idea if the minor changes still meet the 3 python codestyle guidelines.

[and removed the extra def that I accidentally left in]