### PR TITLE
Improved support for passing creds via different methods

### DIFF
--- a/Xcode/AppleDataGatherer.py
+++ b/Xcode/AppleDataGatherer.py
@@ -71,7 +71,7 @@ class AppleDataGatherer(Processor):
                 "You must provide either a password, or a password_file argument."
             )
         password = self.env.get("password")
-        if self.env.get("password_file"):
+        if self.env.get("password_file") and self.env.get("password_file") != "%PASSWORD_FILE%":
             with open(self.env["password_file"]) as f:
                 password = f.read()
         passwordstring = "accountPassword={}".format(password)

--- a/Xcode/Xcode.download.recipe
+++ b/Xcode/Xcode.download.recipe
@@ -11,10 +11,6 @@
     <dict>
       <key>NAME</key>
       <string>Xcode</string>
-      <key>APPLE_ID</key>
-      <string>dev@domain.com</string>
-      <key>PASSWORD_FILE</key>
-      <string>secret.txt</string>
       <key>BETA</key>
       <string></string>
       <key>PATTERN</key>
@@ -37,6 +33,8 @@
           <string>%APPLE_ID%</string>
           <key>password_file</key>
           <string>%PASSWORD_FILE%</string>
+          <key>password</key>
+          <string>%PASSWORD%</string>
           <key>appID_key</key>
           <string>891bd3417a7776362562d2197f89480a8547b108fd934911bcbea0110d07f757</string>
         </dict>


### PR DESCRIPTION
* Better support for the two different methods to pass a password.
* Removed the input parameters for the `APPLE_ID` and `PASSWORD_FILE` variables and added the `password` input variable to the `AppleDataGatherer` processor step.

This was done so that these values can be passed via `autopkg --prefs <file>` or via an override.  Currently the `password` input variable for `AppleDataGatherer` cannot be used in this recipe and overriding it does not allow for this either.

