### PR TITLE
Fix XcodeVersioner processor to fix python crash

### DIFF
--- a/Xcode/XcodeVersioner.py
+++ b/Xcode/XcodeVersioner.py
@@ -70,41 +70,6 @@ class XcodeVersioner(Processor):
 
     __doc__ = description
 
-    def _load_objc_framework(self, f_name, f_path, class_whitelist):
-        loaded = {}
-        framework_bundle = objc.loadBundle(  # NOQA
-            f_name, bundle_path=f_path, module_globals=loaded
-        )
-        desired = {}
-        for x in class_whitelist:
-            if x in loaded:
-                desired[x] = loaded[x]
-        return namedtuple("AttributedFramework", desired.keys())(**desired)
-
-    def xcode_info(self, app_path):
-        DVTFoundation_path = (
-            "%s/Contents/SharedFrameworks/" + "DVTFoundation.framework"
-        ) % app_path
-        desired_classes = ["DVTToolsInfo"]
-        DVTFoundation = self._load_objc_framework(
-            "DVTFoundation", DVTFoundation_path, desired_classes
-        )
-        x_info = DVTFoundation.DVTToolsInfo.toolsInfo()
-        x_v = x_info.toolsVersion()
-        x_b = x_info.toolsBuildVersion()
-        app_info = []
-        app_info.append(["major_version", str(x_v.versionMajorComponent())])
-        app_info.append(["minor_version", str(x_v.versionMinorComponent())])
-        app_info.append(["patch_version", str(x_v.versionUpdateComponent())])
-        app_info.append(["build_version", x_b.name()])
-        is_beta = bool(x_info.isBeta())
-        app_info.append(["is_beta", is_beta])
-        if is_beta:
-            app_info.append(["beta_version", str(x_info.toolsBetaVersion())])
-        else:
-            app_info.append(["beta_version", "0"])
-        return app_info
-
     def main(self):
         """Main."""
         main_version_string = self.env["version"]
@@ -123,20 +88,13 @@ class XcodeVersioner(Processor):
         except IndexError:
             self.output("Normalizing patch to 0")
             self.env["patch_version"] = str("0")
-        self.env["is_beta"] = False
-        xcode_info_results = self.xcode_info(self.env["app_path"])
-        xcode_data = {}
-        for info_pair in xcode_info_results:
-            xcode_data[info_pair[0]] = info_pair[1]
-        if xcode_data["is_beta"]:
-            self.output("Beta version: %s" % xcode_data["beta_version"])
-            self.env["is_beta"] = xcode_data["is_beta"]
-            self.env["beta_version"] = xcode_data["beta_version"]
         self.output("Patch version: %s" % self.env["patch_version"])
-
-        self.env["build_version"] = xcode_data["build_version"]
         self.output("Build version: %s" % self.env["build_version"])
-
+        if "beta_version" not in self.env:
+            self.env["is_beta"] = False
+            self.output("Not a beta version")
+        else:
+            self.output("Beta version: %s" % self.env["beta_version"])
 
 if __name__ == "__main__":
     PROCESSOR = XcodeVersioner()


### PR DESCRIPTION
Fix for https://github.com/facebook/Recipes-for-AutoPkg/issues/59

- Removes the bundle inspection code used to create the "human readable" beta version.

- In the AppleURLSearcher processor, parse the found URL for beta or Release Candidate info and set environment variables for `is_beta` and `beta_version` there.

Output for Xcode 12.1.1 Release Candidate:
```
AppleURLSearcher
{'Input': {'re_pattern': '(.*\\/Xcode_.*\\/Xcode.*.xip)'}}
AppleURLSearcher: No value supplied for result_output_var_name, setting default value of: match
AppleURLSearcher: Beta flag is set, searching Apple downloads URL...
AppleURLSearcher: Parsing for beta version with url: https://developer.apple.com//services-account/download?path=/Developer_Tools/Xcode_12.1.1_Release_Candidate/Xcode_12.1.1_Release_Candidate.xip
AppleURLSearcher: beta_version: Release Candidate
AppleURLSearcher: New fixed URL: https://developer.apple.com//services-account/download?path=/Developer_Tools/Xcode_12.1.1_Release_Candidate/Xcode_12.1.1_Release_Candidate.xip
{'Output': {'match': 'https://developer.apple.com//services-account/download?path=/Developer_Tools/Xcode_12.1.1_Release_Candidate/Xcode_12.1.1_Release_Candidate.xip'}}

...

XcodeVersioner
{'Input': {'app_path': '/Users/victor_desouza/Library/AutoPkg/Cache/local.munki.XcodeLatest/XcodeLatest_unpack/Xcode.app',
           'version': '12.1.1'}}
XcodeVersioner: Major version: 12
XcodeVersioner: Minor version: 1
XcodeVersioner: Patch version: 1
XcodeVersioner: Build version: 12A7605b
XcodeVersioner: Beta version: Release Candidate
{'Output': {'beta_version': 'Release Candidate',
            'build_version': '12A7605b',
            'is_beta': True,
            'major_version': '12',
            'minor_version': '1',
            'patch_version': '1'}}

```

Output for Xcode 13.2 beta 2"
```
AppleURLSearcher
{'Input': {'re_pattern': '(.*\\/Xcode(.*Release_Candidate|.*beta).*\\/Xcode.*.xip)'}}
AppleURLSearcher: No value supplied for result_output_var_name, setting default value of: match
AppleURLSearcher: Beta flag not set, searching More downloads list...
AppleURLSearcher: Sorted list of possible filenames: ['Xcode_11.3_beta', 'Xcode_11.4_beta', 'Xcode_11.4_beta_2', 'Xcode_11.4_beta_3', 'Xcode_11.5_beta', 'Xcode_11.5_beta_2', 'Xcode_11.6_beta', 'Xcode_12_beta', 'Xcode_12_for_macOS_Universal_Apps_beta', 'Xcode_12_for_macOS_Universal_Apps_beta_2', 'Xcode_12_beta_2', 'Xcode_12_beta_3', 'Xcode_12_beta_4', 'Xcode_12_beta_5', 'Xcode_11.7_beta', 'Xcode_12_beta_6', 'Xcode_12.2_beta', 'Xcode_12.2_beta_2', 'Xcode_12.2_beta_3', 'Xcode_12.1.1_Release_Candidate', 'Xcode_12.2_Release_Candidate', 'Xcode_12.3_beta', 'Xcode_12.3_Release_Candidate', 'Xcode_12.4_Release_Candidate', 'Xcode_12.5_beta', 'Xcode_12.5_beta_2', 'Xcode_12.5_beta_3', 'Xcode_12.5_Release_Candidate', 'Xcode_13_beta', 'Xcode_13_beta_2', 'Xcode_13_beta3', 'Xcode_13_beta_4', 'Xcode_13_beta_5', 'Xcode_13.2_beta', 'Xcode_13.2_beta_2']
AppleURLSearcher: Found matching item: Xcode_13.2_beta_2
AppleURLSearcher: Parsing for beta version with url: https://download.developer.apple.com/Developer_Tools/Xcode_13.2_beta_2/Xcode_13.2_beta_2.xip
AppleURLSearcher: beta_version: 2
AppleURLSearcher: Full URL: https://download.developer.apple.com/Developer_Tools/Xcode_13.2_beta_2/Xcode_13.2_beta_2.xip
{'Output': {'match': 'https://download.developer.apple.com/Developer_Tools/Xcode_13.2_beta_2/Xcode_13.2_beta_2.xip'}}

...

XcodeVersioner
{'Input': {'app_path': '/Users/victor_desouza/Library/AutoPkg/Cache/local.munki.XcodeLatest/XcodeLatest_unpack/Xcode-beta.app',
           'version': '13.2'}}
XcodeVersioner: Major version: 13
XcodeVersioner: Minor version: 2
XcodeVersioner: Normalizing patch to 0
XcodeVersioner: Patch version: 0
XcodeVersioner: Build version: 13C5081f
XcodeVersioner: Beta version: 2
{'Output': {'beta_version': '2',
            'build_version': '13C5081f',
            'is_beta': True,
            'major_version': '13',
            'minor_version': '2',
            'patch_version': '0'}}


```